### PR TITLE
Migrate codebase to new organization structure

### DIFF
--- a/src/organization_migration/README.md
+++ b/src/organization_migration/README.md
@@ -1,0 +1,23 @@
+# Migration and Refactor Guide
+
+## Introduction
+This directory contains scripts that help migrate and refactor the codebase to the new organizational structure. The goal is to ensure smooth code transfer while maintaining compatibility with the existing system.
+
+## Steps to Migrate
+
+1. **Set up environment variables**:
+   - `OLD_ORG_SRC_PATH`: Path to the current organization's source code directory.
+   - `NEW_ORG_DEST_PATH`: Path to the new organization's destination directory.
+
+2. **Run migration script**:
+   - Use the `migrate_codebase.py` script to transfer the code to the new structure.
+
+3. **Refactor the code**:
+   - After migration, review the code and adjust it to comply with the new organization's guidelines and practices.
+
+## Considerations
+- Ensure that all paths are correct and match the respective directories before running the script.
+- The migration script will skip any non-code files such as `README.md` and documentation files.
+
+## Conclusion
+The migration process should be seamless if the guidelines are followed and code is refactored properly.

--- a/src/organization_migration/migrate_codebase.py
+++ b/src/organization_migration/migrate_codebase.py
@@ -1,0 +1,42 @@
+import os
+import shutil
+
+# This script helps migrate and refactor code to the new organization structure.
+
+def migrate_codebase(src_dir, dest_dir):
+    """Migrate code from old organization to new one"""
+    # Ensure source and destination directories exist
+    if not os.path.exists(src_dir):
+        raise FileNotFoundError(f'Source directory {src_dir} not found')
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+
+    # Iterate through the files in the source directory and migrate them
+    for root, dirs, files in os.walk(src_dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+            # Skip any files that are not relevant (e.g., read-only files)
+            if file.endswith('.md') or 'README' in file:
+                continue
+
+            # Create the corresponding directory in the destination if it doesn't exist
+            relative_path = os.path.relpath(file_path, src_dir)
+            destination_file_path = os.path.join(dest_dir, relative_path)
+            destination_dir = os.path.dirname(destination_file_path)
+
+            if not os.path.exists(destination_dir):
+                os.makedirs(destination_dir)
+
+            # Copy the file to the new destination
+            shutil.copy(file_path, destination_file_path)
+
+            print(f'Migrated: {file_path} to {destination_file_path}')
+
+if __name__ == '__main__':
+    source_directory = os.getenv('OLD_ORG_SRC_PATH')
+    destination_directory = os.getenv('NEW_ORG_DEST_PATH')
+
+    if not source_directory or not destination_directory:
+        raise ValueError('Source and destination directories must be provided via environment variables.')
+
+    migrate_codebase(source_directory, destination_directory)


### PR DESCRIPTION
Fixed: Migration to new organization structure
Added: Migration script and updated README

The `migrate_codebase.py` script has been added to handle the migration of files, ensuring compatibility with the new directory structure under the @devpool-directory organization. The script migrates relevant files while maintaining their functionality.

The README file has been updated with clear instructions on how to use the migration tool and what steps are needed post-migration to refactor the code as per the new structure.

Closes #331

See commit messages for details.